### PR TITLE
Protection against replay attacks

### DIFF
--- a/Bruno/Create Access Token.bru
+++ b/Bruno/Create Access Token.bru
@@ -21,14 +21,6 @@ body:json {
   }
 }
 
-script:pre-request {
-  const cookie = bru.getVar("cookie");
-  
-  if(cookie) {
-    req.setHeader("Cookie", cookie)
-  }
-}
-
 script:post-response {
   if (res.status >= 200 && res.status < 300) {
     bru.setEnvVar("accessToken", res.body.accessToken);   

--- a/Bruno/Login.bru
+++ b/Bruno/Login.bru
@@ -16,16 +16,3 @@ body:json {
     "Password": "{{password}}"
   }
 }
-
-script:post-response {
-  if (res.status >= 200 && res.status < 300) {
-    bru.setEnvVar("refreshToken", res.body.refreshToken);   
-    bru.setEnvVar("refreshTokenId", res.body.tokenId);
-  }
-  
-  const cookies = res.getHeader('set-cookie');
-  
-  if(cookies) {
-    bru.setVar("cookie", cookies.join('; '));
-  }
-}

--- a/Bruno/Revoke Token.bru
+++ b/Bruno/Revoke Token.bru
@@ -11,5 +11,5 @@ delete {
 }
 
 params:path {
-  id: 5
+  id: 
 }

--- a/Portfolio.Backend/Controllers/AuthenticationController.cs
+++ b/Portfolio.Backend/Controllers/AuthenticationController.cs
@@ -40,7 +40,7 @@ namespace Portfolio.Backend.Controllers
 				return TypedResults.Unauthorized();
 			}
 
-			UpdateRefreshToken(newRefreshToken.token, newRefreshToken.id, newRefreshToken.expiration);
+			UpdateRefreshTokenCookie(newRefreshToken.token, newRefreshToken.id, newRefreshToken.expiration);
 
 			return TypedResults.Ok(new CreatedAccessTokenResponse(accessToken));
 		}
@@ -56,7 +56,7 @@ namespace Portfolio.Backend.Controllers
 				return TypedResults.Unauthorized();
 			}
 
-			UpdateRefreshToken(token, id, expiration);
+			UpdateRefreshTokenCookie(token, id, expiration);
 
 			return TypedResults.Ok();
 		}
@@ -80,7 +80,7 @@ namespace Portfolio.Backend.Controllers
 			return TypedResults.Ok();
 		}
 
-		private void UpdateRefreshToken(string token, uint id, DateTimeOffset expiration)
+		private void UpdateRefreshTokenCookie(string token, uint id, DateTimeOffset expiration)
 		{
 			var combinedToken = $"{id}\t{token}";
 

--- a/Portfolio.Backend/Data/Users/RefreshToken.cs
+++ b/Portfolio.Backend/Data/Users/RefreshToken.cs
@@ -1,0 +1,44 @@
+﻿namespace Portfolio.Backend.Data.Users
+{
+	public class RefreshToken
+	{
+		public uint Id { get; set; }
+		public virtual User Owner { get; set; } = null!;
+		public uint OwnerId { get; set; }
+		public uint ValueId { get; set; }
+		public RefreshTokenValue? Value
+		{
+			get
+			{
+				return HistoricalValues.FirstOrDefault(v => v.Id == ValueId);
+			}
+			set
+			{
+				if (value is null)
+				{
+					ValueId = 0;
+				} else
+				{
+					ValueId = value.Id;
+					HistoricalValues.Add(value);
+				}
+			}
+		}
+
+		public virtual IList<RefreshTokenValue> HistoricalValues { get; set; } = [];
+
+		public DateTimeOffset LastUpdatedDate { get; set; } = DateTimeOffset.UtcNow;
+		public DateTimeOffset ExpirationDate { get; set; } = DateTimeOffset.UtcNow.AddDays(30);
+		public DateTimeOffset CreationDate { get; set; } = DateTimeOffset.UtcNow;
+
+		public bool IsExpired() => DateTimeOffset.UtcNow > ExpirationDate || Value is null;
+	}
+
+	public class RefreshTokenValue
+	{
+		public uint Id { get; set; }
+		public DateTimeOffset CreationDate { get; set; } = DateTimeOffset.UtcNow;
+		public virtual RefreshToken ReferringToken { get; set; } = null!;
+		public byte[] TokenHash { get; set; } = [];
+	}
+}

--- a/Portfolio.Backend/Data/Users/RefreshToken.cs
+++ b/Portfolio.Backend/Data/Users/RefreshToken.cs
@@ -1,44 +1,63 @@
-﻿namespace Portfolio.Backend.Data.Users
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Portfolio.Backend.Data.Users
 {
 	public class RefreshToken
 	{
 		public uint Id { get; set; }
 		public virtual User Owner { get; set; } = null!;
 		public uint OwnerId { get; set; }
-		public uint ValueId { get; set; }
-		public RefreshTokenValue? Value
+
+		[NotMapped]
+		public RefreshTokenValue? ActiveToken => Values.FirstOrDefault(v => !v.IsInvalidated());
+
+		public virtual IList<RefreshTokenValue> Values { get; } = [];
+
+		[NotMapped]
+		public DateTimeOffset LastUpdatedDate => Values.Max(v => v.CreationDate);
+		[NotMapped]
+		public DateTimeOffset ExpirationDate => Values.Max(v => v.ExpirationDate);
+		[NotMapped]
+		public DateTimeOffset CreationDate => Values.Min(v => v.CreationDate);
+
+		public bool IsExpired() => DateTimeOffset.UtcNow > ExpirationDate || ActiveToken is null;
+
+		public void Invalidate()
 		{
-			get
+			foreach (var value in Values.Where(v => !v.IsInvalidated()))
 			{
-				return HistoricalValues.FirstOrDefault(v => v.Id == ValueId);
-			}
-			set
-			{
-				if (value is null)
-				{
-					ValueId = 0;
-				} else
-				{
-					ValueId = value.Id;
-					HistoricalValues.Add(value);
-				}
+				value.Invalidate();
 			}
 		}
 
-		public virtual IList<RefreshTokenValue> HistoricalValues { get; set; } = [];
+		public void NewValue(RefreshTokenValue newToken)
+		{
+			if (ActiveToken is not null && !newToken.IsInvalidated())
+			{
+				ActiveToken?.Invalidate();
+			}
 
-		public DateTimeOffset LastUpdatedDate { get; set; } = DateTimeOffset.UtcNow;
-		public DateTimeOffset ExpirationDate { get; set; } = DateTimeOffset.UtcNow.AddDays(30);
-		public DateTimeOffset CreationDate { get; set; } = DateTimeOffset.UtcNow;
-
-		public bool IsExpired() => DateTimeOffset.UtcNow > ExpirationDate || Value is null;
+			Values.Add(newToken);
+		}
 	}
 
 	public class RefreshTokenValue
 	{
 		public uint Id { get; set; }
+		public uint ReferringTokenId { get; set; }
 		public DateTimeOffset CreationDate { get; set; } = DateTimeOffset.UtcNow;
+		public required DateTimeOffset ExpirationDate { get; set; }
 		public virtual RefreshToken ReferringToken { get; set; } = null!;
 		public byte[] TokenHash { get; set; } = [];
+
+		public bool IsInvalidated()
+		{
+			return DateTimeOffset.UtcNow > ExpirationDate;
+		}
+
+		public void Invalidate()
+		{
+			ExpirationDate = DateTimeOffset.UtcNow;
+		}
 	}
 }

--- a/Portfolio.Backend/Data/Users/User.cs
+++ b/Portfolio.Backend/Data/Users/User.cs
@@ -25,21 +25,10 @@
 		public byte[] PasswordHash { get; set; } = [];
 
 		public byte[] PasswordResetTokenHash { get; set; } = [];
-		public DateTimeOffset PasswordResetExpiration { get; set; } = default;
-		public DateTimeOffset LastPasswordResetRequest { get; set; } = default;
+		public DateTimeOffset PasswordResetExpiration { get; set; }
+		public DateTimeOffset LastPasswordResetRequest { get; set; }
 
 		public virtual IList<RefreshToken> RefreshTokens { get; set; } = [];
-	}
-
-	public class RefreshToken
-	{
-		public uint Id { get; set; }
-		public virtual User Owner { get; set; } = null!;
-		public uint OwnerId { get; set; }
-		public byte[] TokenHash { get; set; } = [];
-
-		public DateTimeOffset LastUpdatedDate { get; set; } = DateTimeOffset.UtcNow;
-		public DateTimeOffset ExpirationDate { get; set; } = DateTimeOffset.UtcNow.AddDays(30);
-		public DateTimeOffset CreationDate { get; set; } = DateTimeOffset.UtcNow;
+		public virtual IReadOnlyList<RefreshToken> ActiveRefreshTokens => RefreshTokens.Where(t => !t.IsExpired()).ToList().AsReadOnly();
 	}
 }

--- a/Portfolio.Backend/Data/Users/User.cs
+++ b/Portfolio.Backend/Data/Users/User.cs
@@ -1,4 +1,6 @@
-﻿namespace Portfolio.Backend.Data.Users
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Portfolio.Backend.Data.Users
 {
 	public class User
 	{
@@ -28,7 +30,8 @@
 		public DateTimeOffset PasswordResetExpiration { get; set; }
 		public DateTimeOffset LastPasswordResetRequest { get; set; }
 
-		public virtual IList<RefreshToken> RefreshTokens { get; set; } = [];
-		public virtual IReadOnlyList<RefreshToken> ActiveRefreshTokens => RefreshTokens.Where(t => !t.IsExpired()).ToList().AsReadOnly();
+		public virtual IList<RefreshToken> RefreshTokens { get; } = [];
+		[NotMapped]
+		public IReadOnlyList<RefreshToken> ActiveRefreshTokens => RefreshTokens.Where(t => !t.IsExpired()).ToList().AsReadOnly();
 	}
 }

--- a/Portfolio.Backend/Extensions/JwtBearerEventsExtensions.cs
+++ b/Portfolio.Backend/Extensions/JwtBearerEventsExtensions.cs
@@ -16,7 +16,7 @@ namespace Portfolio.Backend.Extensions
 
 			options.Events ??= new JwtBearerEvents();
 
-			options.Events.OnTokenValidated += (TokenValidatedContext ctx) =>
+			options.Events.OnTokenValidated += ctx =>
 			{
 				if (ctx.Principal is null)
 					return Task.CompletedTask;
@@ -40,15 +40,13 @@ namespace Portfolio.Backend.Extensions
 					return Task.CompletedTask;
 				}
 
-				if (!user.RefreshTokens.Any(t => t.Id == tokenId))
+				var token = user.RefreshTokens.FirstOrDefault(t => t.Id == tokenId);
+
+				if (token?.IsExpired() is not false)
 				{
 					ctx.Fail(FailureMessage);
 					return Task.CompletedTask;
 				}
-
-				// TODO: Check if the refresh token was already used.
-				// If that's the case, the token should be invalidated as this is probably a replay attack.
-				// Before that, we need to keep all previous refresh tokens in the database.
 
 				return Task.CompletedTask;
 			};

--- a/Portfolio.Backend/Migrations/20250304090038_RefineRefreshTokens.Designer.cs
+++ b/Portfolio.Backend/Migrations/20250304090038_RefineRefreshTokens.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Portfolio.Backend.Services.Implementation;
@@ -11,9 +12,11 @@ using Portfolio.Backend.Services.Implementation;
 namespace Portfolio.Backend.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250304090038_RefineRefreshTokens")]
+    partial class RefineRefreshTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Portfolio.Backend/Migrations/20250304090038_RefineRefreshTokens.cs
+++ b/Portfolio.Backend/Migrations/20250304090038_RefineRefreshTokens.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Portfolio.Backend.Migrations
+{
+	/// <inheritdoc />
+	public partial class RefineRefreshTokens : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.CreateTable(
+				name: "refresh_token_value",
+				columns: table => new
+				{
+					id = table.Column<long>(type: "bigint", nullable: false)
+						.Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn),
+					referring_token_id = table.Column<long>(type: "bigint", nullable: false),
+					creation_date = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+					expiration_date = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+					token_hash = table.Column<byte[]>(type: "bytea", nullable: false)
+				},
+				constraints: table =>
+				{
+					table.PrimaryKey("pk_refresh_token_value", x => x.id);
+					table.ForeignKey(
+						name: "fk_refresh_token_value_refresh_token_referring_token_id",
+						column: x => x.referring_token_id,
+						principalTable: "refresh_token",
+						principalColumn: "id",
+						onDelete: ReferentialAction.Cascade);
+				});
+
+			migrationBuilder.CreateIndex(
+				name: "ix_refresh_token_value_referring_token_id",
+				table: "refresh_token_value",
+				column: "referring_token_id");
+
+			// copy the tokens to the new refresh_token_value table,
+			// and update the referring token to point to the new value
+			migrationBuilder.Sql("""
+			INSERT INTO refresh_token_value (creation_date, expiration_date, referring_token_id, token_hash)
+			    SELECT NOW(), expiration_date, id, token_hash FROM refresh_token
+			""");
+
+			migrationBuilder.DropColumn(
+				name: "creation_date",
+				table: "refresh_token");
+
+			migrationBuilder.DropColumn(
+				name: "expiration_date",
+				table: "refresh_token");
+
+			migrationBuilder.DropColumn(
+				name: "last_updated_date",
+				table: "refresh_token");
+
+			migrationBuilder.DropColumn(
+				name: "token_hash",
+				table: "refresh_token");
+
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<DateTimeOffset>(
+				name: "creation_date",
+				table: "refresh_token",
+				type: "timestamp with time zone",
+				nullable: false,
+				defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+			migrationBuilder.AddColumn<DateTimeOffset>(
+				name: "expiration_date",
+				table: "refresh_token",
+				type: "timestamp with time zone",
+				nullable: false,
+				defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+			migrationBuilder.AddColumn<DateTimeOffset>(
+				name: "last_updated_date",
+				table: "refresh_token",
+				type: "timestamp with time zone",
+				nullable: false,
+				defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+			migrationBuilder.AddColumn<byte[]>(
+				name: "token_hash",
+				table: "refresh_token",
+				type: "bytea",
+				nullable: false,
+				defaultValue: Array.Empty<byte>());
+
+			// copy the values back to the refresh_token table from the newest refresh_token_value
+			// linked to the referring token
+			migrationBuilder.Sql("""
+                UPDATE refresh_token
+                SET token_hash = sub.token_hash,
+                    creation_date = sub.creation_date,
+                    expiration_date = sub.expiration_date,
+                    last_updated_date = sub.creation_date
+                FROM (
+                    SELECT DISTINCT ON (referring_token_id) *
+                    FROM refresh_token_value
+                    ORDER BY referring_token_id, creation_date DESC
+                ) AS sub
+                WHERE sub.referring_token_id = refresh_token.id;
+                """);
+
+			migrationBuilder.DropTable(
+				name: "refresh_token_value");
+
+		}
+	}
+}

--- a/Portfolio.Backend/Program.cs
+++ b/Portfolio.Backend/Program.cs
@@ -81,11 +81,17 @@ builder.Services.AddScoped<IConnection>(sp =>
 builder.Services.AddSingleton<IGravatarRetriever, GravatarRetriever>();
 builder.Services.AddSingleton<ISkillIconsRetriever, SkillIconsRetriever>();
 
+// Add the cryptographic helper service
+builder.Services.AddSingleton<ICryptoHelper, CryptoHelper>();
+
+builder.Services.AddSingleton<IntruderDetector>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<IntruderDetector>());
+builder.Services.AddSingleton<IIntruderDetector>(sp => sp.GetRequiredService<IntruderDetector>());
+
 // Add the email provider which sends password reset emails
 builder.Services.AddTransient<IResetPasswordEmailProvider, ResetPasswordEmailProvider>();
 
-// Add the cryptography helper, email sender, user service and authentication manager
-builder.Services.AddScoped<ICryptoHelper, CryptoHelper>();
+// Add the email sender, user service and authentication manager
 builder.Services.AddScoped<IEmailer, EmailSender>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IAuthenticator, AuthenticationManager>();

--- a/Portfolio.Backend/Services/IIntruderDetector.cs
+++ b/Portfolio.Backend/Services/IIntruderDetector.cs
@@ -1,0 +1,7 @@
+﻿namespace Portfolio.Backend.Services
+{
+	public interface IIntruderDetector
+	{
+		public void EnqueueInvalidAccessTokenUsage(uint tokenId, string usedToken);
+	}
+}

--- a/Portfolio.Backend/Services/Implementation/DatabaseContext.cs
+++ b/Portfolio.Backend/Services/Implementation/DatabaseContext.cs
@@ -35,9 +35,7 @@ namespace Portfolio.Backend.Services.Implementation
 			modelBuilder.Entity<RefreshToken>(entity =>
 			{
 				entity.HasKey(e => e.Id);
-				entity.Property(e => e.ExpirationDate).IsRequired();
-				entity.Property(e => e.CreationDate).IsRequired();
-				entity.HasMany(e => e.HistoricalValues).WithOne(v => v.ReferringToken).OnDelete(DeleteBehavior.Cascade);
+				entity.HasMany(e => e.Values).WithOne(v => v.ReferringToken).OnDelete(DeleteBehavior.Cascade);
 			});
 		}
 	}

--- a/Portfolio.Backend/Services/Implementation/DatabaseContext.cs
+++ b/Portfolio.Backend/Services/Implementation/DatabaseContext.cs
@@ -19,14 +19,9 @@ namespace Portfolio.Backend.Services.Implementation
 				entity.Property(e => e.Email).IsRequired();
 				entity.Property(e => e.PasswordHash).IsRequired();
 
-				entity.OwnsMany(u => u.RefreshTokens, t =>
-				{
-					t.WithOwner(t => t.Owner);
-					t.HasKey(t => t.Id);
-					t.Property(t => t.TokenHash).IsRequired();
-				});
+				entity.HasMany(u => u.RefreshTokens).WithOne(t => t.Owner).HasForeignKey(t => t.OwnerId).OnDelete(DeleteBehavior.Cascade);
 
-				entity.Property(u => u.NameSlug).HasComputedColumnSql("""lower(regexp_replace(full_name, E'[^a-zA-Z0-9_]+', '-', 'gi'))""", stored: true);
+				entity.Property(u => u.NameSlug).HasComputedColumnSql("lower(regexp_replace(full_name, E'[^a-zA-Z0-9_]+', '-', 'gi'))", stored: true);
 
 				entity.HasData(new User
 				{
@@ -35,6 +30,14 @@ namespace Portfolio.Backend.Services.Implementation
 					FullName = "Jonathan Bout",
 					Description = "Yes. It's me.",
 				});
+			});
+
+			modelBuilder.Entity<RefreshToken>(entity =>
+			{
+				entity.HasKey(e => e.Id);
+				entity.Property(e => e.ExpirationDate).IsRequired();
+				entity.Property(e => e.CreationDate).IsRequired();
+				entity.HasMany(e => e.HistoricalValues).WithOne(v => v.ReferringToken).OnDelete(DeleteBehavior.Cascade);
 			});
 		}
 	}

--- a/Portfolio.Backend/Services/Implementation/IntruderDetector.cs
+++ b/Portfolio.Backend/Services/Implementation/IntruderDetector.cs
@@ -1,0 +1,89 @@
+﻿
+using Octokit.GraphQL.Model;
+using Portfolio.Backend.Data.Users;
+using System.Collections.Concurrent;
+
+namespace Portfolio.Backend.Services.Implementation
+{
+	public class IntruderDetector(ICryptoHelper cryptoHelper, IServiceProvider services) : IIntruderDetector, IHostedService
+	{
+		private readonly ICryptoHelper _crypto = cryptoHelper;
+		private readonly IServiceProvider _serviceProvider = services;
+		private readonly CancellationTokenSource _backgroundServiceCts = new();
+		private Task? _backgroundServiceTask = null;
+
+		private readonly ConcurrentQueue<Func<IServiceProvider, CancellationToken, Task>> _work = new();
+
+		public void EnqueueInvalidAccessTokenUsage(uint tokenId, string usedToken)
+		{
+			_work.Enqueue((sp, ct) =>
+			{
+				var db = sp.GetRequiredService<DatabaseContext>();
+				if (db.Set<RefreshToken>().Find(tokenId) is RefreshToken token)
+				{
+					var crypto = sp.GetRequiredService<ICryptoHelper>();
+					// check if the token is an old one. At most 10, as the verification is quite an expensive operation
+					foreach (var oldToken in token.HistoricalValues.OrderBy(v => v.CreationDate))
+					{
+						if (ct.IsCancellationRequested)
+							return Task.CompletedTask;
+
+						if (_crypto.Verify(usedToken, oldToken.TokenHash) == VerificationResult.Success)
+						{
+							// the token is an old one, this means someone is trying to reuse an old token.
+							// this is known as a replay attack and we should not allow it.
+							// For the sake of security, we will completely invalidate the token
+
+							var authenticationManager = sp.GetRequiredService<IAuthenticator>();
+
+							authenticationManager.RevokeRefreshToken(token.Owner, token.Id);
+							break;
+						}
+					}
+				}
+
+				return Task.CompletedTask;
+			});
+
+			Awake();
+		}
+
+		private void Awake()
+		{
+			if (_backgroundServiceTask is not null)
+				return;
+
+			_backgroundServiceTask = Task.Run(async () =>
+			{
+				while (!_backgroundServiceCts.Token.IsCancellationRequested)
+				{
+					if (_work.TryDequeue(out var work))
+					{
+						using var scope = _serviceProvider.CreateScope();
+						using var cts = CancellationTokenSource.CreateLinkedTokenSource(_backgroundServiceCts.Token);
+
+						var workTask = Task.Run(async () => await work(scope.ServiceProvider, cts.Token), cts.Token);
+
+						// we want to make sure that we don't block the queue for too long.
+						// we will set a timeout based on the amount of work in the queue
+						var timeout = int.Max(10_000 / int.Max(1, _work.Count), 1000);
+
+						cts.CancelAfter(timeout);
+
+						await workTask;
+					} else
+					{
+						return;
+					}
+				}
+			}).ContinueWith(_ =>
+			{
+				_backgroundServiceTask?.Dispose();
+				_backgroundServiceTask = null;
+			});
+		}
+
+		public Task StartAsync(CancellationToken cancellationToken) => Task.FromCanceled(cancellationToken);
+		public Task StopAsync(CancellationToken cancellationToken) => _backgroundServiceCts.CancelAsync();
+	}
+}


### PR DESCRIPTION
Refresh tokens are recycled on every request for an access token. Old refresh tokens are stored in the database. With this history of tokens, we can check if the request is part of a replay attack, as the token should match one of the invalidated tokens in the database.