### PR TITLE
Modify Docker publish workflow for compatibility

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,24 +42,17 @@ jobs:
     if: github.event_name != 'pull_request' # can't use env here for some reason
     needs: 
     - test # require tests to pass before publishing
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      # Install the cosign tool except on PR
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
-        if: env.IS_PRODUCTION_BUILD == 'true'
-        with:
-          cosign-release: 'v2.2.4'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
       # Login against a Docker registry except on PR
       - name: Log into registry ${{ env.REGISTRY }}
@@ -101,19 +94,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: 'linux/arm64'
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: env.IS_PRODUCTION_BUILD == 'true'
-        env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+          platforms: linux/arm64,linux/amd64


### PR DESCRIPTION
Updated the Docker publish workflow to remove cosign installation and signing steps. Changed the runner to ubuntu-24.04 and added QEMU setup.